### PR TITLE
Add GitHub Actions workflow

### DIFF
--- a/.github/scripts/gradlew_recursive.sh
+++ b/.github/scripts/gradlew_recursive.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Copyright (C) 2020 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -xe
+
+# Default Gradle settings are not optimal for Android builds, override them
+# here to make the most out of the GitHub Actions build servers
+GRADLE_OPTS="$GRADLE_OPTS -Xms4g -Xmx4g"
+GRADLE_OPTS="$GRADLE_OPTS -XX:+HeapDumpOnOutOfMemoryError"
+GRADLE_OPTS="$GRADLE_OPTS -Dorg.gradle.daemon=false"
+GRADLE_OPTS="$GRADLE_OPTS -Dorg.gradle.workers.max=2"
+GRADLE_OPTS="$GRADLE_OPTS -Dkotlin.incremental=false"
+GRADLE_OPTS="$GRADLE_OPTS -Dkotlin.compiler.execution.strategy=in-process"
+GRADLE_OPTS="$GRADLE_OPTS -Dfile.encoding=UTF-8"
+export GRADLE_OPTS
+
+# Crawl all gradlew files which indicate an Android project
+# You may edit this if your repo has a different project structure
+for GRADLEW in `find . -name "gradlew"` ; do
+    SAMPLE=$(dirname "${GRADLEW}")
+    # Tell Gradle that this is a CI environment and disable parallel compilation
+    bash "$GRADLEW" -p "$SAMPLE" -Pci --no-parallel --stacktrace $@
+done

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,43 @@
+# Copyright (C) 2020 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Android CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-18.04
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Build project
+        run: .github/scripts/gradlew_recursive.sh assembleDebug
+      - name: Zip artifacts
+        run: zip -r assemble.zip . -i '**/build/*.apk' '**/build/*.aab' '**/build/*.aar' '**/build/*.so'
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: assemble
+          path: assemble.zip


### PR DESCRIPTION
This enables automatic builds for new commits and PRs in the master branch.
This sample is currently **green**, see build logs:

+ GRADLE_OPTS=' -Xms4g -Xmx4g'
+ GRADLE_OPTS=' -Xms4g -Xmx4g -XX:+HeapDumpOnOutOfMemoryError'
+ GRADLE_OPTS=' -Xms4g -Xmx4g -XX:+HeapDumpOnOutOfMemoryError -Dorg.gradle.daemon=false'
+ GRADLE_OPTS=' -Xms4g -Xmx4g -XX:+HeapDumpOnOutOfMemoryError -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2'
+ GRADLE_OPTS=' -Xms4g -Xmx4g -XX:+HeapDumpOnOutOfMemoryError -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2 -Dkotlin.incremental=false'
+ GRADLE_OPTS=' -Xms4g -Xmx4g -XX:+HeapDumpOnOutOfMemoryError -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2 -Dkotlin.incremental=false -Dkotlin.compiler.execution.strategy=in-process'
+ GRADLE_OPTS=' -Xms4g -Xmx4g -XX:+HeapDumpOnOutOfMemoryError -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2 -Dkotlin.incremental=false -Dkotlin.compiler.execution.strategy=in-process -Dfile.encoding=UTF-8'
+ export GRADLE_OPTS
++ find . -name gradlew
+ for GRADLEW in '`find . -name "gradlew"`'
++ dirname ./AutofillFrameworkKotlin/gradlew
+ SAMPLE=./AutofillFrameworkKotlin
+ bash ./AutofillFrameworkKotlin/gradlew -p ./AutofillFrameworkKotlin -Pci --no-parallel --stacktrace assembleDebug

> Configure project :Application
WARNING: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html
WARNING: The specified Android SDK Build Tools version (26.0.1) is ignored, as it is below the minimum supported version (28.0.3) for Android Gradle Plugin 3.3.0.
Android SDK Build Tools 28.0.3 will be used.
To suppress this warning, remove "buildToolsVersion '26.0.1'" from your build.gradle file, as each version of the Android Gradle Plugin now has a default version of the build tools.

> Task :Application:preBuild UP-TO-DATE
> Task :Application:preDebugBuild
> Task :Application:compileDebugAidl NO-SOURCE
> Task :Application:compileDebugRenderscript
> Task :Application:checkDebugManifest
> Task :Application:generateDebugBuildConfig
> Task :Application:mainApkListPersistenceDebug
> Task :Application:generateDebugResValues
> Task :Application:generateDebugResources
> Task :Application:mergeDebugResources
> Task :Application:createDebugCompatibleScreenManifests
> Task :Application:processDebugManifest
> Task :Application:processDebugResources

> Task :Application:compileDebugKotlin
w: /Users/owahltinez/Sandbox/samples/input-samples/AutofillFrameworkKotlin/Application/src/main/java/com/example/android/autofillframework/app/CustomVirtualView.kt: (145, 22): Variable 'upperY' initializer is redundant
w: /Users/owahltinez/Sandbox/samples/input-samples/AutofillFrameworkKotlin/Application/src/main/java/com/example/android/autofillframework/multidatasetservice/settings/SettingsActivity.kt: (54, 58): Parameter 'compoundButton' is never used, could be renamed to _
w: /Users/owahltinez/Sandbox/samples/input-samples/AutofillFrameworkKotlin/Application/src/main/java/com/example/android/autofillframework/multidatasetservice/settings/SettingsActivity.kt: (61, 58): Parameter 'compoundButton' is never used, could be renamed to _
w: /Users/owahltinez/Sandbox/samples/input-samples/AutofillFrameworkKotlin/Application/src/main/java/com/example/android/autofillframework/multidatasetservice/settings/SettingsActivity.kt: (86, 59): Parameter 'which' is never used, could be renamed to _
w: /Users/owahltinez/Sandbox/samples/input-samples/AutofillFrameworkKotlin/Application/src/main/java/com/example/android/autofillframework/multidatasetservice/settings/SettingsActivity.kt: (108, 59): Parameter 'which' is never used, could be renamed to _
w: /Users/owahltinez/Sandbox/samples/input-samples/AutofillFrameworkKotlin/Application/src/main/java/com/example/android/autofillframework/multidatasetservice/settings/SettingsActivity.kt: (126, 59): Parameter 'which' is never used, could be renamed to _

> Task :Application:prepareLintJar
> Task :Application:generateDebugSources
> Task :Application:javaPreCompileDebug
> Task :Application:compileDebugJavaWithJavac
> Task :Application:compileDebugNdk NO-SOURCE
> Task :Application:compileDebugSources
> Task :Application:mergeDebugShaders
> Task :Application:compileDebugShaders
> Task :Application:generateDebugAssets
> Task :Application:mergeDebugAssets
> Task :Application:mergeExtDexDebug
> Task :Application:mergeLibDexDebug
> Task :Application:transformClassesWithDexBuilderForDebug
> Task :Application:mergeProjectDexDebug
> Task :Application:validateSigningDebug
> Task :Application:signingConfigWriterDebug
> Task :Application:mergeDebugJniLibFolders
> Task :Application:transformNativeLibsWithMergeJniLibsForDebug
> Task :Application:transformNativeLibsWithStripDebugSymbolForDebug
> Task :Application:processDebugJavaRes NO-SOURCE
> Task :Application:transformResourcesWithMergeJavaResForDebug
> Task :Application:packageDebug
> Task :Application:assembleDebug

Deprecated Gradle features were used in this build, making it incompatible with Gradle 6.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/5.1.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 41s
28 actionable tasks: 28 executed
+ for GRADLEW in '`find . -name "gradlew"`'
++ dirname ./BasicMultitouch/gradlew
+ SAMPLE=./BasicMultitouch
+ bash ./BasicMultitouch/gradlew -p ./BasicMultitouch -Pci --no-parallel --stacktrace assembleDebug
> Task :Application:preBuild UP-TO-DATE
> Task :Application:preDebugBuild
> Task :Application:compileDebugAidl NO-SOURCE
> Task :Application:compileDebugRenderscript NO-SOURCE
> Task :Application:checkDebugManifest
> Task :Application:generateDebugBuildConfig
> Task :Application:prepareLintJar
> Task :Application:generateDebugSources
> Task :Application:javaPreCompileDebug
> Task :Application:mainApkListPersistenceDebug
> Task :Application:generateDebugResValues
> Task :Application:generateDebugResources
> Task :Application:mergeDebugResources
> Task :Application:createDebugCompatibleScreenManifests
> Task :Application:processDebugManifest
> Task :Application:processDebugResources

> Task :Application:compileDebugJavaWithJavac
Note: /Users/owahltinez/Sandbox/samples/input-samples/BasicMultitouch/Application/src/main/java/com/example/android/common/logger/LogFragment.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.

> Task :Application:compileDebugSources
> Task :Application:mergeDebugShaders
> Task :Application:compileDebugShaders
> Task :Application:generateDebugAssets
> Task :Application:mergeDebugAssets
> Task :Application:checkDebugDuplicateClasses
> Task :Application:mergeExtDexDebug
> Task :Application:transformClassesWithDexBuilderForDebug
> Task :Application:mergeDexDebug
> Task :Application:validateSigningDebug
> Task :Application:signingConfigWriterDebug
> Task :Application:mergeDebugJniLibFolders
> Task :Application:transformNativeLibsWithMergeJniLibsForDebug
> Task :Application:transformNativeLibsWithStripDebugSymbolForDebug
> Task :Application:processDebugJavaRes NO-SOURCE
> Task :Application:transformResourcesWithMergeJavaResForDebug
> Task :Application:packageDebug
> Task :Application:assembleDebug

Deprecated Gradle features were used in this build, making it incompatible with Gradle 6.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/5.1.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 21s
26 actionable tasks: 26 executed
+ for GRADLEW in '`find . -name "gradlew"`'
++ dirname ./CommitContentSampleIME/gradlew
+ SAMPLE=./CommitContentSampleIME
+ bash ./CommitContentSampleIME/gradlew -p ./CommitContentSampleIME -Pci --no-parallel --stacktrace assembleDebug
To honour the JVM settings for this build a new JVM will be forked. Please consider using the daemon: https://docs.gradle.org/5.1.1/userguide/gradle_daemon.html.
Daemon will be stopped at the end of the build stopping after processing

> Configure project :app
WARNING: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html
WARNING: Configuration 'androidTestCompile' is obsolete and has been replaced with 'androidTestImplementation'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html
WARNING: Configuration 'testCompile' is obsolete and has been replaced with 'testImplementation'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html

> Task :app:preBuild UP-TO-DATE
> Task :app:preDebugBuild
> Task :app:compileDebugAidl NO-SOURCE
> Task :app:compileDebugRenderscript
> Task :app:checkDebugManifest
> Task :app:generateDebugBuildConfig
> Task :app:prepareLintJar
> Task :app:generateDebugSources
> Task :app:javaPreCompileDebug
> Task :app:mainApkListPersistenceDebug
> Task :app:generateDebugResValues
> Task :app:generateDebugResources
> Task :app:mergeDebugResources
> Task :app:createDebugCompatibleScreenManifests
> Task :app:processDebugManifest
> Task :app:processDebugResources
> Task :app:compileDebugJavaWithJavac
> Task :app:compileDebugNdk NO-SOURCE
> Task :app:compileDebugSources
> Task :app:mergeDebugShaders
> Task :app:compileDebugShaders
> Task :app:generateDebugAssets
> Task :app:mergeDebugAssets
> Task :app:mergeExtDexDebug
> Task :app:transformClassesWithDexBuilderForDebug
> Task :app:mergeDexDebug
> Task :app:validateSigningDebug
> Task :app:signingConfigWriterDebug
> Task :app:mergeDebugJniLibFolders
> Task :app:transformNativeLibsWithMergeJniLibsForDebug
> Task :app:transformNativeLibsWithStripDebugSymbolForDebug
> Task :app:processDebugJavaRes NO-SOURCE
> Task :app:transformResourcesWithMergeJavaResForDebug
> Task :app:packageDebug
> Task :app:assembleDebug

Deprecated Gradle features were used in this build, making it incompatible with Gradle 6.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/5.1.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 23s
26 actionable tasks: 26 executed
+ for GRADLEW in '`find . -name "gradlew"`'
++ dirname ./CommitContentSampleApp/gradlew
+ SAMPLE=./CommitContentSampleApp
+ bash ./CommitContentSampleApp/gradlew -p ./CommitContentSampleApp -Pci --no-parallel --stacktrace assembleDebug
To honour the JVM settings for this build a new JVM will be forked. Please consider using the daemon: https://docs.gradle.org/5.1.1/userguide/gradle_daemon.html.
Daemon will be stopped at the end of the build stopping after processing

> Configure project :app
WARNING: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html
WARNING: Configuration 'androidTestCompile' is obsolete and has been replaced with 'androidTestImplementation'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html
WARNING: Configuration 'testCompile' is obsolete and has been replaced with 'testImplementation'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html

> Task :app:preBuild UP-TO-DATE
> Task :app:preDebugBuild
> Task :app:compileDebugAidl NO-SOURCE
> Task :app:compileDebugRenderscript
> Task :app:checkDebugManifest
> Task :app:generateDebugBuildConfig
> Task :app:prepareLintJar
> Task :app:generateDebugSources
> Task :app:javaPreCompileDebug
> Task :app:mainApkListPersistenceDebug
> Task :app:generateDebugResValues
> Task :app:generateDebugResources
> Task :app:mergeDebugResources
> Task :app:createDebugCompatibleScreenManifests
> Task :app:processDebugManifest
> Task :app:processDebugResources
> Task :app:compileDebugJavaWithJavac
> Task :app:compileDebugNdk NO-SOURCE
> Task :app:compileDebugSources
> Task :app:mergeDebugShaders
> Task :app:compileDebugShaders
> Task :app:generateDebugAssets
> Task :app:mergeDebugAssets
> Task :app:mergeExtDexDebug
> Task :app:transformClassesWithDexBuilderForDebug
> Task :app:mergeDexDebug
> Task :app:validateSigningDebug
> Task :app:signingConfigWriterDebug
> Task :app:mergeDebugJniLibFolders
> Task :app:transformNativeLibsWithMergeJniLibsForDebug
> Task :app:transformNativeLibsWithStripDebugSymbolForDebug
> Task :app:processDebugJavaRes NO-SOURCE
> Task :app:transformResourcesWithMergeJavaResForDebug
> Task :app:packageDebug
> Task :app:assembleDebug

Deprecated Gradle features were used in this build, making it incompatible with Gradle 6.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/5.1.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 22s
26 actionable tasks: 26 executed
+ for GRADLEW in '`find . -name "gradlew"`'
++ dirname ./AutofillFramework/gradlew
+ SAMPLE=./AutofillFramework
+ bash ./AutofillFramework/gradlew -p ./AutofillFramework -Pci --no-parallel --stacktrace assembleDebug
> Task :afservice:preBuild UP-TO-DATE
> Task :afservice:preDebugBuild
> Task :afservice:compileDebugAidl NO-SOURCE
> Task :afservice:compileDebugRenderscript
> Task :afservice:checkDebugManifest
> Task :afservice:generateDebugBuildConfig
> Task :afservice:prepareLintJar
> Task :afservice:generateDebugSources
> Task :afservice:javaPreCompileDebug
> Task :afservice:mainApkListPersistenceDebug
> Task :afservice:generateDebugResValues
> Task :afservice:generateDebugResources
> Task :afservice:mergeDebugResources
> Task :afservice:createDebugCompatibleScreenManifests
> Task :afservice:processDebugManifest
> Task :afservice:processDebugResources

> Task :afservice:compileDebugJavaWithJavac
Gradle may disable incremental compilation as the following annotation processors are not incremental: compiler-1.0.0.jar (android.arch.persistence.room:compiler:1.0.0).
Consider setting the experimental feature flag android.enableSeparateAnnotationProcessing=true in the gradle.properties file to run annotation processing in a separate task and make compilation incremental.
warning: Supported source version 'RELEASE_7' from annotation processor 'org.gradle.api.internal.tasks.compile.processing.TimeTrackingProcessor' less than -source '1.8'
/Users/owahltinez/Sandbox/samples/input-samples/AutofillFramework/afservice/src/main/java/com/example/android/autofill/service/model/FilledAutofillField.java:32: warning: fieldTypeName column references a foreign key but it is not part of an index. This may trigger full table scans whenever parent table is modified so you are highly advised to create an index that covers this column.
public class FilledAutofillField {
       ^
/Users/owahltinez/Sandbox/samples/input-samples/AutofillFramework/afservice/src/main/java/com/example/android/autofill/service/model/AutofillHint.java:27: warning: fieldTypeName column references a foreign key but it is not part of an index. This may trigger full table scans whenever parent table is modified so you are highly advised to create an index that covers this column.
public class AutofillHint {
       ^
/Users/owahltinez/Sandbox/samples/input-samples/AutofillFramework/afservice/src/main/java/com/example/android/autofill/service/model/ResourceIdHeuristic.java:27: warning: fieldTypeName column references a foreign key but it is not part of an index. This may trigger full table scans whenever parent table is modified so you are highly advised to create an index that covers this column.
public class ResourceIdHeuristic {
       ^
/Users/owahltinez/Sandbox/samples/input-samples/AutofillFramework/afservice/src/main/java/com/example/android/autofill/service/data/source/local/dao/AutofillDao.java:46: warning:  com.example.android.autofill.service.model.DatasetWithFilledAutofillFields has some fields [packageName] which are not returned by the query. If they are not supposed to be read from the result, you can mark them with @Ignore annotation. You can suppress this warning by annotating the method with @SuppressWarnings(RoomWarnings.CURSOR_MISMATCH). Columns returned by the query: id, datasetName. Fields in com.example.android.autofill.service.model.DatasetWithFilledAutofillFields: id, datasetName, packageName.
    List<DatasetWithFilledAutofillFields> getDatasets(List<String> allAutofillHints);
                                          ^
/Users/owahltinez/Sandbox/samples/input-samples/AutofillFramework/afservice/src/main/java/com/example/android/autofill/service/data/source/local/dao/AutofillDao.java:46: warning: The return value includes a Pojo with a @Relation. It is usually desired to annotate this method with @Transaction to avoid possibility of inconsistent results between the Pojo and its relations. See https://developer.android.com/reference/android/arch/persistence/room/Transaction.html for details.
    List<DatasetWithFilledAutofillFields> getDatasets(List<String> allAutofillHints);
                                          ^
/Users/owahltinez/Sandbox/samples/input-samples/AutofillFramework/afservice/src/main/java/com/example/android/autofill/service/data/source/local/dao/AutofillDao.java:50: warning:  com.example.android.autofill.service.model.DatasetWithFilledAutofillFields has some fields [packageName] which are not returned by the query. If they are not supposed to be read from the result, you can mark them with @Ignore annotation. You can suppress this warning by annotating the method with @SuppressWarnings(RoomWarnings.CURSOR_MISMATCH). Columns returned by the query: id, datasetName. Fields in com.example.android.autofill.service.model.DatasetWithFilledAutofillFields: id, datasetName, packageName.
    List<DatasetWithFilledAutofillFields> getAllDatasets();
                                          ^
/Users/owahltinez/Sandbox/samples/input-samples/AutofillFramework/afservice/src/main/java/com/example/android/autofill/service/data/source/local/dao/AutofillDao.java:50: warning: The return value includes a Pojo with a @Relation. It is usually desired to annotate this method with @Transaction to avoid possibility of inconsistent results between the Pojo and its relations. See https://developer.android.com/reference/android/arch/persistence/room/Transaction.html for details.
    List<DatasetWithFilledAutofillFields> getAllDatasets();
                                          ^
/Users/owahltinez/Sandbox/samples/input-samples/AutofillFramework/afservice/src/main/java/com/example/android/autofill/service/data/source/local/dao/AutofillDao.java:65: warning:  com.example.android.autofill.service.model.DatasetWithFilledAutofillFields has some fields [packageName] which are not returned by the query. If they are not supposed to be read from the result, you can mark them with @Ignore annotation. You can suppress this warning by annotating the method with @SuppressWarnings(RoomWarnings.CURSOR_MISMATCH). Columns returned by the query: id, datasetName. Fields in com.example.android.autofill.service.model.DatasetWithFilledAutofillFields: id, datasetName, packageName.
    List<DatasetWithFilledAutofillFields> getDatasetsWithName(
                                          ^
/Users/owahltinez/Sandbox/samples/input-samples/AutofillFramework/afservice/src/main/java/com/example/android/autofill/service/data/source/local/dao/AutofillDao.java:65: warning: The return value includes a Pojo with a @Relation. It is usually desired to annotate this method with @Transaction to avoid possibility of inconsistent results between the Pojo and its relations. See https://developer.android.com/reference/android/arch/persistence/room/Transaction.html for details.
    List<DatasetWithFilledAutofillFields> getDatasetsWithName(
                                          ^
/Users/owahltinez/Sandbox/samples/input-samples/AutofillFramework/afservice/src/main/java/com/example/android/autofill/service/data/source/local/dao/AutofillDao.java:77: warning: The return value includes a Pojo with a @Relation. It is usually desired to annotate this method with @Transaction to avoid possibility of inconsistent results between the Pojo and its relations. See https://developer.android.com/reference/android/arch/persistence/room/Transaction.html for details.
    List<FieldTypeWithHeuristics> getFieldTypesWithHints();
                                  ^
/Users/owahltinez/Sandbox/samples/input-samples/AutofillFramework/afservice/src/main/java/com/example/android/autofill/service/data/source/local/dao/AutofillDao.java:89: warning: The return value includes a Pojo with a @Relation. It is usually desired to annotate this method with @Transaction to avoid possibility of inconsistent results between the Pojo and its relations. See https://developer.android.com/reference/android/arch/persistence/room/Transaction.html for details.
    List<FieldTypeWithHeuristics> getFieldTypesForAutofillHints(List<String> autofillHints);
                                  ^
/Users/owahltinez/Sandbox/samples/input-samples/AutofillFramework/afservice/src/main/java/com/example/android/autofill/service/data/source/local/dao/AutofillDao.java:94: warning:  com.example.android.autofill.service.model.DatasetWithFilledAutofillFields has some fields [packageName] which are not returned by the query. If they are not supposed to be read from the result, you can mark them with @Ignore annotation. You can suppress this warning by annotating the method with @SuppressWarnings(RoomWarnings.CURSOR_MISMATCH). Columns returned by the query: id, datasetName. Fields in com.example.android.autofill.service.model.DatasetWithFilledAutofillFields: id, datasetName, packageName.
    DatasetWithFilledAutofillFields getAutofillDatasetWithId(String datasetId);
                                    ^
/Users/owahltinez/Sandbox/samples/input-samples/AutofillFramework/afservice/src/main/java/com/example/android/autofill/service/data/source/local/dao/AutofillDao.java:94: warning: The return value includes a Pojo with a @Relation. It is usually desired to annotate this method with @Transaction to avoid possibility of inconsistent results between the Pojo and its relations. See https://developer.android.com/reference/android/arch/persistence/room/Transaction.html for details.
    DatasetWithFilledAutofillFields getAutofillDatasetWithId(String datasetId);
                                    ^
/Users/owahltinez/Sandbox/samples/input-samples/AutofillFramework/afservice/src/main/java/com/example/android/autofill/service/data/source/local/db/AutofillDatabase.java:52: warning: Schema export directory is not provided to the annotation processor so we cannot export the schema. You can either provide `room.schemaLocation` annotation processor argument OR set exportSchema to false.
public abstract class AutofillDatabase extends RoomDatabase {
                ^
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: /Users/owahltinez/Sandbox/samples/input-samples/AutofillFramework/afservice/build/generated/source/apt/debug/com/example/android/autofill/service/data/source/local/dao/AutofillDao_Impl.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
15 warnings

> Task :afservice:compileDebugNdk NO-SOURCE
> Task :afservice:compileDebugSources
> Task :afservice:mergeDebugShaders
> Task :afservice:compileDebugShaders
> Task :afservice:generateDebugAssets
> Task :afservice:mergeDebugAssets
> Task :afservice:validateSigningDebug
> Task :afservice:signingConfigWriterDebug
> Task :afservice:transformClassesWithDexBuilderForDebug
> Task :afservice:transformDexArchiveWithExternalLibsDexMergerForDebug
> Task :afservice:transformDexArchiveWithDexMergerForDebug
> Task :afservice:mergeDebugJniLibFolders
> Task :afservice:transformNativeLibsWithMergeJniLibsForDebug
> Task :afservice:transformNativeLibsWithStripDebugSymbolForDebug
> Task :afservice:processDebugJavaRes NO-SOURCE
> Task :afservice:transformResourcesWithMergeJavaResForDebug
> Task :afservice:packageDebug
> Task :afservice:assembleDebug
> Task :Application:preBuild UP-TO-DATE
> Task :Application:preDebugBuild
> Task :Application:compileDebugAidl NO-SOURCE
> Task :Application:compileDebugRenderscript
> Task :Application:checkDebugManifest
> Task :Application:generateDebugBuildConfig
> Task :Application:prepareLintJar
> Task :Application:generateDebugSources
> Task :Application:javaPreCompileDebug
> Task :Application:mainApkListPersistenceDebug
> Task :Application:generateDebugResValues
> Task :Application:generateDebugResources
> Task :Application:mergeDebugResources
> Task :Application:createDebugCompatibleScreenManifests
> Task :Application:processDebugManifest
> Task :Application:processDebugResources

Note: /Users/owahltinez/Sandbox/samples/input-samples/AutofillFramework/Application/src/main/java/com/example/android/autofill/app/commoncases/RecyclerViewActivity.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
> Task :Application:compileDebugJavaWithJavac

> Task :Application:compileDebugNdk NO-SOURCE
> Task :Application:compileDebugSources
> Task :Application:mergeDebugShaders
> Task :Application:compileDebugShaders
> Task :Application:generateDebugAssets
> Task :Application:mergeDebugAssets
> Task :Application:validateSigningDebug
> Task :Application:signingConfigWriterDebug
> Task :Application:transformClassesWithDexBuilderForDebug
> Task :Application:transformDexArchiveWithExternalLibsDexMergerForDebug
> Task :Application:transformDexArchiveWithDexMergerForDebug
> Task :Application:mergeDebugJniLibFolders
> Task :Application:transformNativeLibsWithMergeJniLibsForDebug
> Task :Application:transformNativeLibsWithStripDebugSymbolForDebug
> Task :Application:processDebugJavaRes NO-SOURCE
> Task :Application:transformResourcesWithMergeJavaResForDebug
> Task :Application:packageDebug
> Task :Application:assembleDebug

Deprecated Gradle features were used in this build, making it incompatible with Gradle 6.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/5.1.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 52s
52 actionable tasks: 52 executed
+ for GRADLEW in '`find . -name "gradlew"`'
++ dirname ./BasicGestureDetect/gradlew
+ SAMPLE=./BasicGestureDetect
+ bash ./BasicGestureDetect/gradlew -p ./BasicGestureDetect -Pci --no-parallel --stacktrace assembleDebug
> Task :Application:preBuild UP-TO-DATE
> Task :Application:preDebugBuild
> Task :Application:compileDebugAidl NO-SOURCE
> Task :Application:compileDebugRenderscript NO-SOURCE
> Task :Application:checkDebugManifest
> Task :Application:generateDebugBuildConfig
> Task :Application:prepareLintJar
> Task :Application:generateDebugSources
> Task :Application:javaPreCompileDebug
> Task :Application:mainApkListPersistenceDebug
> Task :Application:generateDebugResValues
> Task :Application:generateDebugResources
> Task :Application:mergeDebugResources
> Task :Application:createDebugCompatibleScreenManifests
> Task :Application:processDebugManifest
> Task :Application:processDebugResources

Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
> Task :Application:compileDebugJavaWithJavac

> Task :Application:compileDebugSources
> Task :Application:mergeDebugShaders
> Task :Application:compileDebugShaders
> Task :Application:generateDebugAssets
> Task :Application:mergeDebugAssets
> Task :Application:checkDebugDuplicateClasses
> Task :Application:mergeExtDexDebug
> Task :Application:transformClassesWithDexBuilderForDebug
> Task :Application:mergeDexDebug
> Task :Application:validateSigningDebug
> Task :Application:signingConfigWriterDebug
> Task :Application:mergeDebugJniLibFolders
> Task :Application:transformNativeLibsWithMergeJniLibsForDebug
> Task :Application:transformNativeLibsWithStripDebugSymbolForDebug
> Task :Application:processDebugJavaRes NO-SOURCE
> Task :Application:transformResourcesWithMergeJavaResForDebug
> Task :Application:packageDebug
> Task :Application:assembleDebug

Deprecated Gradle features were used in this build, making it incompatible with Gradle 6.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/5.1.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 25s
26 actionable tasks: 26 executed
