### PR TITLE
Add build workflows for Android sample apps

### DIFF
--- a/.github/workflows/build-autofill-framework-application.yml
+++ b/.github/workflows/build-autofill-framework-application.yml
@@ -1,0 +1,33 @@
+# Workflow name
+name: Build AutofillFramework Application
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set Up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+          cache: 'gradle'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+        working-directory: ./AutofillFramework
+
+      - name: Build AutofillFramework Application app
+        working-directory: ./AutofillFramework
+        run: ./gradlew Application:assembleDebug

--- a/.github/workflows/build-basic-gesture-detect.yml
+++ b/.github/workflows/build-basic-gesture-detect.yml
@@ -1,0 +1,33 @@
+# Workflow name
+name: Build BasicGestureDetect
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set Up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+          cache: 'gradle'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+        working-directory: ./BasicGestureDetect
+
+      - name: Build BasicGestureDetect app
+        working-directory: ./BasicGestureDetect
+        run: ./gradlew Application:assembleDebug

--- a/.github/workflows/build-commit-content-sample-app.yml
+++ b/.github/workflows/build-commit-content-sample-app.yml
@@ -1,0 +1,33 @@
+# Workflow name
+name: Build CommitContentSampleApp
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set Up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+          cache: 'gradle'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+        working-directory: ./CommitContentSampleApp
+
+      - name: Build CommitContentSampleApp app
+        working-directory: ./CommitContentSampleApp
+        run: ./gradlew app:assembleDebug


### PR DESCRIPTION
This commit adds new GitHub Actions workflows to build the following Android sample applications:

- AutofillFramework
- BasicGestureDetect
- CommitContentSampleApp

These workflows are triggered on push, pull request, and workflow_dispatch events, and they build the debug APK for each application.